### PR TITLE
* some improvements to pivot reports built on TKGrid:

### DIFF
--- a/src/grid/mKGridUtils.pas
+++ b/src/grid/mKGridUtils.pas
@@ -1,0 +1,48 @@
+// This is part of the Obo Component Library
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This software is distributed without any warranty.
+//
+// @author Domenico Mammola (mimmo71@gmail.com - www.mammola.net)
+
+unit mKGridUtils;
+
+{$IFDEF FPC}
+  {$MODE DELPHI}
+{$ENDIF}
+
+interface
+
+uses
+  kgrids;
+
+procedure AutoSizeColumns(aGrid : TKGrid);
+
+implementation
+
+uses
+  math;
+
+procedure AutoSizeColumns(aGrid: TKGrid);
+var
+  i : integer;
+  total, w : integer;
+  ratio : double;
+begin
+  aGrid.AutoSizeGrid(mpColWidth);
+  total := 0;
+  for i := 0 to aGrid.FixedCols - 1 do
+    total := total + aGrid.ColWidths[i];
+  w := trunc (aGrid.Width * 0.95);
+  if total >= w then
+  begin
+    ratio := total / w;
+    for i := 0 to aGrid.FixedCols - 1 do
+      aGrid.ColWidths[i] := max(5, trunc(aGrid.ColWidths[i] / ratio));
+  end;
+end;
+
+end.

--- a/src/pivot/mVirtualGridKGrid.pas
+++ b/src/pivot/mVirtualGridKGrid.pas
@@ -44,7 +44,8 @@ type
 implementation
 
 uses
-  kfunctions;
+  kfunctions,
+  mKGridUtils;
 
 { TmKGridAsVirtualGrid }
 
@@ -135,7 +136,8 @@ end;
 
 procedure TmKGridAsVirtualGrid.AutosizeColumns;
 begin
-  FGrid.AutoSizeGrid(mpColWidth);
+  mKGridUtils.AutoSizeColumns(FGrid);
 end;
 
 end.
+

--- a/src/uramaki/UramakiKGridAsPivotPlate.pas
+++ b/src/uramaki/UramakiKGridAsPivotPlate.pas
@@ -45,6 +45,9 @@ resourcestring
   SUnableToWriteFileMessage = 'Unable to write file. Check if the file is open by another application. If so, close it and run this command again. Detail:';
   SWantToOpenFileMessage = 'Do you want to open the file?';
   SExcelFileDescription = 'Excel 97-2003 files';
+  SAutoAdjustColumnsMenuCaption = 'Auto-size columns';
+  SAutoAdjustColumnsMenuHint = 'Set optimal width to columns';
+  SPivotActionsHint = 'Pivot actions...';
 
 type
 
@@ -60,15 +63,17 @@ type
     FFilterPanel : TmFilterPanel;
     FToolbar : TUramakiToolbar;
     FConfigurePopupMenu : TPopupMenu;
+    FPivotCommandsPopupMenu : TPopupMenu;
     FSaveDialog : TSaveDialog;
 
     procedure OnClearFilter (Sender : TObject);
     procedure OnExecuteFilter (Sender : TObject);
     procedure ReloadData (aFilters : TmFilters); virtual; abstract;
     procedure ProcessClearChilds(var Message: {$IFDEF FPC}TLMessage{$ELSE}TMessage{$ENDIF}); message WM_USER_CLEARCHILDS;
-    procedure CreateToolbar(aImageList : TImageList; aConfigureImageIndex, aRefreshChildsImageIndex, aGridCommandsImageIndex : integer);
+    procedure CreateToolbar(aImageList : TImageList; aConfigureImageIndex, aRefreshChildsImageIndex, aPivotCommandsImageIndex : integer);
     procedure OnEditSettings(Sender : TObject);
     procedure OnExportToXlsFile(Sender : TObject);
+    procedure OnAutoAdjustColumns(Sender : TObject);
     function ConfirmFileOverwrite : boolean;
   public
     constructor Create(TheOwner: TComponent); override;
@@ -143,7 +148,7 @@ begin
   EngineMediator.PleaseClearMyChilds(Self);
 end;
 
-procedure TUramakiKGridAsPivotPlate.CreateToolbar(aImageList: TImageList; aConfigureImageIndex, aRefreshChildsImageIndex, aGridCommandsImageIndex: integer);
+procedure TUramakiKGridAsPivotPlate.CreateToolbar(aImageList: TImageList; aConfigureImageIndex, aRefreshChildsImageIndex, aPivotCommandsImageIndex: integer);
 var
   mItm : TMenuItem;
 begin
@@ -152,6 +157,7 @@ begin
   FToolbar.Parent := Self;
 
   FConfigurePopupMenu := TPopupMenu.Create(FToolbar);
+  FPivotCommandsPopupMenu := TPopupMenu.Create(FToolbar);
 
   with FToolbar.AddDropDownButton(FConfigurePopupMenu) do
   begin
@@ -175,6 +181,22 @@ begin
   mItm.OnClick:= Self.OnExportToXlsFile;
   mItm.Hint:= SExportPivotAsXlsCommandHint;
   mItm.Caption:= SExportPivotAsXlsCommandCaption;
+
+  FToolbar.AddSeparator;
+  with FToolbar.AddDropDownButton(FPivotCommandsPopupMenu) do
+  begin
+    Hint:= SPivotActionsHint;
+    ImageIndex:=aPivotCommandsImageIndex;
+    Kind := bkIcon;
+  end;
+  FToolbar.AddSeparator;
+  FToolbar.Update;
+
+  mItm := TMenuItem.Create(FPivotCommandsPopupMenu);
+  FPivotCommandsPopupMenu.Items.Add(mItm);
+  mItm.OnClick:= Self.OnAutoAdjustColumns;
+  mItm.Hint:= SAutoAdjustColumnsMenuHint;
+  mItm.Caption:= SAutoAdjustColumnsMenuCaption;
 
   FToolbar.Update;
 end;
@@ -256,6 +278,11 @@ begin
       end;
     end;
   end;
+end;
+
+procedure TUramakiKGridAsPivotPlate.OnAutoAdjustColumns(Sender: TObject);
+begin
+  FGridHelper.AutosizeColumns;
 end;
 
 function TUramakiKGridAsPivotPlate.ConfirmFileOverwrite: boolean;


### PR DESCRIPTION
  - as fixed columns are not scrollable, autosize columns function now compute single column widths so that the sum of them doesn't exceed the width of the grid
  - add a command to the standard toolbar to invoke the autosize columns function
  - while scrolling up and down, header cells are drawn trying to to keep the text inside always visible